### PR TITLE
use _destroy instead of destroy

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -86,11 +86,10 @@ Decoder.prototype._transform = function (data, enc, cb) {
   cb()
 }
 
-Decoder.prototype.destroy = function (err) {
-  if (this._destroyed) return
+Decoder.prototype._destroy = function (err, cb) {
+  if (this._destroyed) return cb(err)
   this._destroyed = true
-  if (err) this.emit('error', err)
-  this.emit('close')
+  cb(err)
 }
 
 module.exports = Decoder

--- a/encode.js
+++ b/encode.js
@@ -30,11 +30,10 @@ Encoder.prototype._transform = function (data, enc, cb) {
   cb()
 }
 
-Encoder.prototype.destroy = function (err) {
-  if (this._destroyed) return
+Encoder.prototype._destroy = function (err, cb) {
+  if (this._destroyed) return cb(err)
   this._destroyed = true
-  if (err) this.emit('error', err)
-  this.emit('close')
+  cb(err)
 }
 
 module.exports = Encoder


### PR DESCRIPTION
This uses `_destroy` instead of `destroy`. The 2.0.0 release doesn't work with async iterators because streams leverage an undocumented callback param in `.destroy(err, cb)` to handle promise resolution: https://github.com/nodejs/readable-stream/blob/v3.0.0/lib/internal/streams/async_iterator.js#L159. Switching to `_destroy` the emits should no longer be needed.